### PR TITLE
formatters: fix gcov parsing if there are "unexecuted blocks"

### DIFF
--- a/formatters/gcov/gcov.go
+++ b/formatters/gcov/gcov.go
@@ -110,6 +110,12 @@ func parseSourceFile(fileName string, gitHead *object.Commit) (formatters.Source
 		case "#####":
 			sf.Coverage = append(sf.Coverage, formatters.NewNullInt(0))
 		default: // coverage is number of hits
+			// trailing * means that gcov detected an unexecuted block, and we don't
+			// care that deeply. Example - a single-line if (x) { a } else { b } will
+			// report with an asterisk if block b is never executed.
+			if len(coverage) > 0 && coverage[len(coverage)-1] == '*' {
+				coverage = coverage[:len(coverage)-1]
+			}
 			num, err := strconv.Atoi(coverage)
 			if err != nil {
 				return sf, errors.WithStack(err)

--- a/formatters/gcov/gcov.go
+++ b/formatters/gcov/gcov.go
@@ -107,7 +107,7 @@ func parseSourceFile(fileName string, gitHead *object.Commit) (formatters.Source
 		switch coverage {
 		case "-":
 			sf.Coverage = append(sf.Coverage, formatters.NullInt{})
-		case "#####":
+		case "#####", "=====":
 			sf.Coverage = append(sf.Coverage, formatters.NewNullInt(0))
 		default: // coverage is number of hits
 			// trailing * means that gcov detected an unexecuted block, and we don't


### PR DESCRIPTION
Ref: https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Invoking-Gcov.html