### PR TITLE
Add custom file format for simplecov coverage type

### DIFF
--- a/formatters/simplecov/custom_formatter.go
+++ b/formatters/simplecov/custom_formatter.go
@@ -1,0 +1,39 @@
+package simplecov
+
+import (
+	"encoding/json"
+	"github.com/codeclimate/test-reporter/formatters"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"os"
+)
+
+func customFormat(r Formatter, rep formatters.Report) (formatters.Report, error) {
+	logrus.Debugf("Analyzing simplecov json output from custom format %s", r.Path)
+	jf, err := os.Open(r.Path)
+	if err != nil {
+		return rep, errors.WithStack(errors.Errorf("could not open coverage file %s", r.Path))
+	}
+
+	m := map[string]simplecovJsonFormatterReport{}
+	err = json.NewDecoder(jf).Decode(&m)
+	if err != nil {
+		return rep, err
+	}
+
+	for _, v := range m {
+		for n, ls := range v.CoverageType {
+			fe, err := formatters.NewSourceFile(n, nil)
+			if err != nil {
+				return rep, errors.WithStack(err)
+			}
+			fe.Coverage = transformLineCoverageToCoverage(ls.LineCoverage)
+			err = rep.AddSourceFile(fe)
+			if err != nil {
+				return rep, errors.WithStack(err)
+			}
+		}
+	}
+
+	return rep, nil
+}

--- a/formatters/simplecov/simplecov-example-custom.json
+++ b/formatters/simplecov/simplecov-example-custom.json
@@ -1,0 +1,166 @@
+{
+  "RSpec": {
+    "coverage": {
+      "/src/tmp/aruba/project/lib/faked_project.rb": {
+        "lines": [
+          null,
+          null,
+          1,
+          1,
+          1,
+          null,
+          null,
+          null,
+          5,
+          3,
+          null,
+          null,
+          1
+        ]
+      },
+      "/src/tmp/aruba/project/lib/faked_project/framework_specific.rb": {
+        "lines": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          1,
+          1,
+          1,
+          0,
+          null,
+          null,
+          1,
+          1,
+          null,
+          null,
+          1,
+          0,
+          null,
+          null,
+          null
+        ]
+      },
+      "/src/tmp/aruba/project/lib/faked_project/meta_magic.rb": {
+        "lines": [
+          null,
+          null,
+          1,
+          1,
+          1,
+          1,
+          null,
+          null,
+          null,
+          1,
+          1,
+          1,
+          null,
+          null,
+          null,
+          1,
+          1,
+          1,
+          null,
+          1,
+          1,
+          1,
+          null,
+          null,
+          null,
+          null
+        ]
+      },
+      "/src/tmp/aruba/project/lib/faked_project/some_class.rb": {
+        "lines": [
+          null,
+          null,
+          1,
+          1,
+          1,
+          null,
+          1,
+          2,
+          null,
+          null,
+          1,
+          1,
+          null,
+          null,
+          1,
+          1,
+          1,
+          null,
+          0,
+          null,
+          null,
+          0,
+          null,
+          null,
+          1,
+          null,
+          1,
+          0,
+          null,
+          null
+        ]
+      },
+      "/src/tmp/aruba/project/spec/forking_spec.rb": {
+        "lines": [
+          null,
+          null,
+          1,
+          null,
+          1,
+          1,
+          null,
+          1,
+          null,
+          null
+        ]
+      },
+      "/src/tmp/aruba/project/spec/meta_magic_spec.rb": {
+        "lines": [
+          null,
+          null,
+          1,
+          null,
+          1,
+          1,
+          1,
+          null,
+          null,
+          1,
+          1,
+          null,
+          null,
+          1,
+          1,
+          null,
+          null
+        ]
+      },
+      "/src/tmp/aruba/project/spec/some_class_spec.rb": {
+        "lines": [
+          null,
+          null,
+          1,
+          null,
+          1,
+          3,
+          null,
+          1,
+          1,
+          null,
+          null,
+          1,
+          1,
+          null,
+          null
+        ]
+      }
+    },
+    "timestamp": 1720455492
+  }
+}

--- a/formatters/simplecov/simplecov.go
+++ b/formatters/simplecov/simplecov.go
@@ -38,6 +38,10 @@ func (r Formatter) Format() (formatters.Report, error) {
 	rep, err = jsonFormat(r, rep)
 
 	if err != nil {
+		rep, err = customFormat(r, rep)
+	}
+
+	if err != nil {
 		rep, err = legacyFormat(r, rep)
 	}
 

--- a/formatters/simplecov/simplecov_test.go
+++ b/formatters/simplecov/simplecov_test.go
@@ -142,6 +142,23 @@ func Test_FormatWithBranch(t *testing.T) {
 	assert.Equal(lc.Total, 57)
 }
 
+func Test_CustomFormat(t *testing.T) {
+	assert := require.New(t)
+
+	formatter := Formatter{
+		Path: "./simplecov-example-custom.json",
+	}
+	rep, err := formatter.Format()
+	assert.NoError(err)
+
+	assert.InDelta(91.80, rep.CoveredPercent, 1)
+
+	lc := rep.LineCounts
+	assert.Equal(lc.Covered, 56)
+	assert.Equal(lc.Missed, 5)
+	assert.Equal(lc.Total, 61)
+}
+
 func Test_FormatWithBranchWithNoCovLines(t *testing.T) {
 	assert := require.New(t)
 


### PR DESCRIPTION
Most of the repos I checked use this format for coverage files. Which is something between the legacy and new version. The main differences that this format has:
 - there is no metadata fields;
 - it contains high level name, which can be configured by the users;
 - it uses lines and branches primitives (same as the new version).